### PR TITLE
Capture PR metadata from gh pr create

### DIFF
--- a/test/list_test.go
+++ b/test/list_test.go
@@ -192,10 +192,10 @@ func TestList_ShowsCurrentBranch_OnTrunk(t *testing.T) {
 
 func TestList_ShowsPRInfo(t *testing.T) {
 	_, cleanup := setupMockCommandsWithPR(t, mockPROptions{
-		ID:      "PR_kwDOTest123",
-		State:   "OPEN",
-		URL:     "https://github.com/test/test/pull/42",
-		IsDraft: false,
+		CreatedID:      "PR_kwDOTest123",
+		CreatedState:   "OPEN",
+		CreatedURL:     "https://github.com/test/test/pull/42",
+		CreatedIsDraft: boolPtr(false),
 	})
 	defer cleanup()
 
@@ -248,10 +248,10 @@ func TestList_ShowsPRInfo(t *testing.T) {
 
 func TestList_ShowsDraftPR(t *testing.T) {
 	_, cleanup := setupMockCommandsWithPR(t, mockPROptions{
-		ID:      "PR_kwDOTest456",
-		State:   "OPEN",
-		URL:     "https://github.com/test/test/pull/99",
-		IsDraft: true,
+		CreatedID:      "PR_kwDOTest456",
+		CreatedState:   "OPEN",
+		CreatedURL:     "https://github.com/test/test/pull/99",
+		CreatedIsDraft: boolPtr(true),
 	})
 	defer cleanup()
 

--- a/test/testdata/mock-cmd.sh
+++ b/test/testdata/mock-cmd.sh
@@ -52,7 +52,28 @@ case "$CMD_NAME" in
             exit 0
         elif [[ "$1" == "pr" && "$2" == "create" ]]; then
             # Simulate successful PR creation
-            echo "https://github.com/test/test/pull/1"
+            created_id="${YAS_TEST_CREATED_PR_ID:-PR_kwDOTestCreated}"
+            created_state="${YAS_TEST_CREATED_PR_STATE:-OPEN}"
+            created_url="${YAS_TEST_CREATED_PR_URL:-https://github.com/test/test/pull/1}"
+            if [ -n "$YAS_TEST_CREATED_PR_IS_DRAFT" ]; then
+                created_is_draft="$YAS_TEST_CREATED_PR_IS_DRAFT"
+            else
+                created_is_draft="true"
+            fi
+
+            has_json="false"
+            for arg in "$@"; do
+                if [ "$arg" == "--json" ]; then
+                    has_json="true"
+                    break
+                fi
+            done
+
+            if [ "$has_json" == "true" ]; then
+                echo "{\"id\":\"$created_id\",\"state\":\"$created_state\",\"url\":\"$created_url\",\"isDraft\":$created_is_draft}"
+            else
+                echo "$created_url"
+            fi
             exit 0
         fi
         ;;


### PR DESCRIPTION
## Summary
- capture JSON output from `gh pr create` so newly created PRs are written to the state file
- add parsing helpers and metadata assertions to ensure PR URLs appear in `yas list`
- update mock GitHub CLI script to emit configurable JSON for tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e659e6cd38832a84abe642cffd19a2