### PR TITLE
Add `--all` flag to `yas list`

### DIFF
--- a/pkg/yascli/list.go
+++ b/pkg/yascli/list.go
@@ -5,6 +5,7 @@ import (
 )
 
 type listCmd struct {
+	All          bool `description:"Show all local git branches, including untracked ones"                     long:"all"`
 	CurrentStack bool `description:"Show only the current stack (ancestors and descendants of current branch)" long:"current-stack"`
 	Status       bool `description:"Show PR review and CI status"                                              long:"status"`
 }
@@ -15,5 +16,5 @@ func (c *listCmd) Execute(args []string) error {
 		return NewError(err.Error())
 	}
 
-	return yasInstance.List(c.CurrentStack, c.Status)
+	return yasInstance.List(c.CurrentStack, c.Status, c.All)
 }

--- a/test/branch_test.go
+++ b/test/branch_test.go
@@ -41,7 +41,7 @@ func TestBranch_GetBranchList_ForInteractiveSwitcher(t *testing.T) {
 	y, err := yas.NewFromRepository(tempDir)
 	assert.NilError(t, err)
 
-	items, err := y.GetBranchList(false, false)
+	items, err := y.GetBranchList(false, false, false)
 	assert.NilError(t, err)
 
 	// Verify we get the expected branches
@@ -106,7 +106,7 @@ func TestBranch_GetBranchList_MultiLevelStack(t *testing.T) {
 	y, err := yas.NewFromRepository(tempDir)
 	assert.NilError(t, err)
 
-	items, err := y.GetBranchList(false, false)
+	items, err := y.GetBranchList(false, false, false)
 	assert.NilError(t, err)
 
 	// Verify we get all branches in the stack
@@ -168,7 +168,7 @@ func TestBranch_GetBranchList_ForkedBranches(t *testing.T) {
 	y, err := yas.NewFromRepository(tempDir)
 	assert.NilError(t, err)
 
-	items, err := y.GetBranchList(false, false)
+	items, err := y.GetBranchList(false, false, false)
 	assert.NilError(t, err)
 
 	// Verify we get all branches including the fork
@@ -221,7 +221,7 @@ func TestBranch_GetBranchList_CurrentBranchHighlight(t *testing.T) {
 	y, err := yas.NewFromRepository(tempDir)
 	assert.NilError(t, err)
 
-	items, err := y.GetBranchList(false, false)
+	items, err := y.GetBranchList(false, false, false)
 	assert.NilError(t, err)
 
 	// Verify current branch is highlighted with *
@@ -261,7 +261,7 @@ func TestBranch_GetBranchList_EmptyBranchList(t *testing.T) {
 	y, err := yas.NewFromRepository(tempDir)
 	assert.NilError(t, err)
 
-	items, err := y.GetBranchList(false, false)
+	items, err := y.GetBranchList(false, false, false)
 	assert.NilError(t, err)
 
 	// Should only have main branch
@@ -292,7 +292,7 @@ func TestBranch_GetBranchList_SingleBranch(t *testing.T) {
 	y, err := yas.NewFromRepository(tempDir)
 	assert.NilError(t, err)
 
-	items, err := y.GetBranchList(false, false)
+	items, err := y.GetBranchList(false, false, false)
 	assert.NilError(t, err)
 
 	// Should have only main branch
@@ -329,7 +329,7 @@ func TestBranch_GetBranchList_BranchNameFormatting(t *testing.T) {
 	y, err := yas.NewFromRepository(tempDir)
 	assert.NilError(t, err)
 
-	items, err := y.GetBranchList(false, false)
+	items, err := y.GetBranchList(false, false, false)
 	assert.NilError(t, err)
 
 	// Should display formatted branch name with greyed prefix


### PR DESCRIPTION
* Shows all branches including the ones not "tracked" by yas
* Branches not tracked and in dark grey and we don't query status

TODO:
* Improve test coverage
* Add `IsTracked` to BranchMetadata to make the code clearer