### PR TITLE
Add `--draft` flag to `yas submit`

### DIFF
--- a/pkg/yascli/submit.go
+++ b/pkg/yascli/submit.go
@@ -7,6 +7,7 @@ import (
 type submitCmd struct {
 	Stack    bool `description:"Submit all branches in the current stack" long:"stack"`
 	Outdated bool `description:"Submit all branches that need submitting" long:"outdated"`
+	Draft    bool `description:"Create new PRs as draft" long:"draft"`
 }
 
 func (c *submitCmd) Execute(args []string) error {
@@ -16,12 +17,12 @@ func (c *submitCmd) Execute(args []string) error {
 	}
 
 	if c.Outdated {
-		return yasInstance.SubmitOutdated()
+		return yasInstance.SubmitOutdated(c.Draft)
 	}
 
 	if c.Stack {
-		return yasInstance.SubmitStack()
+		return yasInstance.SubmitStack(c.Draft)
 	}
 
-	return yasInstance.Submit()
+	return yasInstance.Submit(c.Draft)
 }

--- a/test/annotate_test.go
+++ b/test/annotate_test.go
@@ -74,7 +74,7 @@ func TestAnnotate_UpdatesPRWithStackInfo(t *testing.T) {
 		// Submit topic-b to create a PR
 		testutil.ExecOrFail(t, "git checkout topic-b")
 
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Run annotate
@@ -160,7 +160,7 @@ func TestAnnotate_SinglePRInStack_DoesNotAddStackSection(t *testing.T) {
 		// Submit to create a PR
 		testutil.ExecOrFail(t, "git checkout topic-a")
 
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Run annotate - should not add stack section
@@ -226,7 +226,7 @@ Stacked PRs:
 		// Submit to create a PR - this calls annotate internally
 		testutil.ExecOrFail(t, "git checkout topic-a")
 
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Read the body file to get the result from submit's annotate call

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -255,7 +255,7 @@ func TestList_ShowsPRInfo(t *testing.T) {
 		assert.NilError(t, err)
 
 		// Submit to create PR and populate metadata
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Capture the list output
@@ -315,7 +315,7 @@ func TestList_ShowsDraftPR(t *testing.T) {
 		assert.NilError(t, err)
 
 		// Submit to create PR and populate metadata
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Capture the list output

--- a/test/merge_test.go
+++ b/test/merge_test.go
@@ -294,7 +294,7 @@ func TestMerge_FailsWhenCINotPassing(t *testing.T) {
 		assert.NilError(t, err)
 
 		// Submit first to simulate that PR exists and is up to date
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Reload instance to get updated metadata
@@ -361,7 +361,7 @@ func TestMerge_FailsWhenNotApproved(t *testing.T) {
 		assert.NilError(t, err)
 
 		// Submit first to simulate that PR exists and is up to date
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Reload instance to get updated metadata
@@ -428,7 +428,7 @@ func TestMerge_SucceedsWithForceFlag(t *testing.T) {
 		assert.NilError(t, err)
 
 		// Submit first to simulate that PR exists and is up to date
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Set EDITOR to a script that just adds a comment to the merge message
@@ -516,7 +516,7 @@ func TestMerge_AbortsWhenMergeMessageEmpty(t *testing.T) {
 		assert.NilError(t, err)
 
 		// Submit first to simulate that PR exists and is up to date
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Set EDITOR to a script that clears the file (simulating user deleting content)

--- a/test/restack_test.go
+++ b/test/restack_test.go
@@ -256,7 +256,7 @@ func TestRestack_ShowsReminderWhenBranchesWithPRsAreRestacked(t *testing.T) {
 		// Submit topic-a to create a PR and populate metadata
 		testutil.ExecOrFail(t, "git checkout topic-a")
 
-		err = y.Submit()
+		err = y.Submit(false)
 		assert.NilError(t, err)
 
 		// Go back to topic-b and restack


### PR DESCRIPTION
* PRs are not created not in draft, by default
* To make new PRs in a draft state, use `yas submit --draft`