### PR TITLE
Make restack consistent with other commands

### DIFF
--- a/pkg/yas/restack.go
+++ b/pkg/yas/restack.go
@@ -37,10 +37,6 @@ func (yas *YAS) Restack(branch string, dryRun bool) error {
 		return err
 	}
 
-	if branch == "" {
-		branch = yas.cfg.TrunkBranch
-	}
-
 	// Remember the starting branch
 	startingBranch, err := yas.git.GetCurrentBranchName()
 	if err != nil {

--- a/pkg/yascli/restack.go
+++ b/pkg/yascli/restack.go
@@ -19,13 +19,23 @@ func (c *restackCmd) Execute(args []string) error {
 		return NewError(err.Error())
 	}
 
+	branch := c.Args.Branch
+
 	if c.All {
-		if c.Args.Branch != "" {
+		if branch != "" {
 			return NewError("specifying a branch is incompatible with --all")
 		}
 
-		c.Args.Branch = yasInstance.Config().TrunkBranch
+		branch = yasInstance.Config().TrunkBranch
+	} else if branch == "" {
+		// Default to current branch when no branch specified and --all not used
+		currentBranch, err := yasInstance.CurrentBranchName()
+		if err != nil {
+			return NewError(err.Error())
+		}
+
+		branch = currentBranch
 	}
 
-	return yasInstance.Restack(c.Args.Branch, c.DryRun)
+	return yasInstance.Restack(branch, c.DryRun)
 }

--- a/test/abort_test.go
+++ b/test/abort_test.go
@@ -125,8 +125,9 @@ func TestAbort_ReturnsToStartingBranch(t *testing.T) {
 	// Verify we're on topic-b
 	equalLines(t, mustExecOutput(tempDir, "git", "branch", "--show-current"), "topic-b")
 
-	// Run restack - it should fail due to conflict on topic-a
-	result := cli.Run("restack")
+	// Run restack --all - it should fail due to conflict on topic-a
+	// (using --all to restack all branches, not just current branch and descendants)
+	result := cli.Run("restack", "--all")
 	assert.Equal(t, result.ExitCode(), 1, "restack should fail due to conflict")
 
 	// During a rebase conflict, we're in detached HEAD state
@@ -190,8 +191,9 @@ func TestAbort_LeavesRebasedBranchesIntact(t *testing.T) {
 	assert.NilError(t, cli.Run("add", "topic-a", "--parent=main").Err())
 	assert.NilError(t, cli.Run("add", "topic-b", "--parent=topic-a").Err())
 
-	// Run restack - topic-a will succeed, topic-b will fail
-	result := cli.Run("restack")
+	// Run restack --all - topic-a will succeed, topic-b will fail
+	// (using --all to restack all branches, not just current branch and descendants)
+	result := cli.Run("restack", "--all")
 	assert.Equal(t, result.ExitCode(), 1, "restack should fail due to conflict on topic-b")
 
 	// Verify restack state exists and shows the correct branch

--- a/test/continue_test.go
+++ b/test/continue_test.go
@@ -54,8 +54,9 @@ func TestContinue_ResumeAfterConflict(t *testing.T) {
 	assert.NilError(t, cli.Run("add", "topic-a", "--parent=main").Err())
 	assert.NilError(t, cli.Run("add", "topic-b", "--parent=topic-a").Err())
 
-	// Run restack - it should fail due to conflict on topic-a
-	result := cli.Run("restack")
+	// Run restack --all - it should fail due to conflict on topic-a
+	// (using --all to restack all branches, not just current branch and descendants)
+	result := cli.Run("restack", "--all")
 	assert.Equal(t, result.ExitCode(), 1, "restack should fail due to conflict")
 
 	// Verify that restack state was saved
@@ -306,8 +307,9 @@ func TestContinue_MultipleConflicts(t *testing.T) {
 	assert.NilError(t, cli.Run("add", "topic-b", "--parent=topic-a").Err())
 	assert.NilError(t, cli.Run("add", "topic-c", "--parent=topic-b").Err())
 
-	// Run restack - it should fail on topic-a
-	result := cli.Run("restack")
+	// Run restack --all - it should fail on topic-a
+	// (using --all to restack all branches, not just current branch and descendants)
+	result := cli.Run("restack", "--all")
 	assert.Equal(t, result.ExitCode(), 1, "restack should fail on topic-a")
 
 	// Fix conflict for topic-a


### PR DESCRIPTION
* `yas restack` - restacks current branch
* `yas restack --all` restacks all branches that need restacking
* `yas restack <branch>` - restack the specified branch

Closes #65.