### PR TITLE
Tolerate stale worktree paths in LinkedWorktrees

### DIFF
--- a/pkg/gitexec/gitexec_test.go
+++ b/pkg/gitexec/gitexec_test.go
@@ -1,6 +1,7 @@
 package gitexec
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -260,4 +261,39 @@ func TestGetRemoteForBranch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLinkedWorktreesTolerateStalePath(t *testing.T) {
+	t.Parallel()
+
+	repoPath := t.TempDir()
+	worktreePath := filepath.Join(t.TempDir(), "stale-worktree")
+
+	testutil.ExecOrFail(t, repoPath, `
+		git init
+		git checkout -b main
+		git config user.email "test@example.com"
+		git config user.name "Test User"
+		git commit --allow-empty -m "initial commit"
+		git branch feature
+		git worktree add `+worktreePath+` feature
+	`)
+
+	// Simulate a stale/prunable worktree by removing its directory without
+	// running `git worktree prune`. Git still lists the entry, but its path no
+	// longer exists on disk.
+	assert.NilError(t, os.RemoveAll(worktreePath))
+
+	repo := WithRepo(repoPath)
+
+	// LinkedWorktrees should not error on the missing path; the stale entry is
+	// skipped.
+	linked, err := repo.LinkedWorktrees()
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(linked))
+
+	// Deleting an unrelated branch must not be blocked by the stale worktree.
+	path, err := repo.LinkedWorktreePathForBranch("some-other-branch")
+	assert.NilError(t, err)
+	assert.Equal(t, "", path)
 }

--- a/pkg/gitexec/worktrees.go
+++ b/pkg/gitexec/worktrees.go
@@ -3,6 +3,7 @@ package gitexec
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -92,6 +93,14 @@ func (r *Repo) LinkedWorktrees() ([]WorktreeEntry, error) {
 	for _, wt := range worktrees {
 		isSameRealPath, err := fsutil.IsSameRealPath(wt.Path, primaryWorktreePath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				// Stale/prunable worktree entry whose path no longer exists
+				// (e.g. git reports it as "prunable gitdir file points to
+				// non-existent location"). There is nothing to operate on, so
+				// skip it rather than aborting the whole operation.
+				continue
+			}
+
 			return nil, err
 		}
 


### PR DESCRIPTION
## Problem

yas crashes when the git repo has a stale/prunable worktree entry — a worktree registration whose directory no longer exists on disk. git itself flags these:

```
worktree /private/tmp/1
branch refs/heads/bar
prunable gitdir file points to non-existent location
```

The failure chain:

1. `yas sync` tries to delete a branch (`pkg/yascli/sync.go`)
2. `DeleteBranch` calls `LinkedWorktreePathForBranch` (`pkg/yas/branch.go`)
3. That calls `LinkedWorktrees`, which compares every worktree against the primary via `fsutil.IsSameRealPath` (`pkg/gitexec/worktrees.go`)
4. `IsSameRealPath` calls `filepath.EvalSymlinks(path)`, which fails with a not-exist error for the stale path — aborting the whole operation, even though that worktree is unrelated to the branch being deleted.

## Fix

In `LinkedWorktrees`, when `IsSameRealPath` returns an `os.IsNotExist` error, skip that worktree entry instead of returning the error. A path that doesn't exist can't be the primary worktree and there's nothing to operate on, so skipping is safe and keeps unrelated operations working. Non-`IsNotExist` errors are still propagated.

## Testing

- Added `TestLinkedWorktreesTolerateStalePath` which creates a worktree, removes its directory to simulate a stale/prunable entry, and verifies `LinkedWorktrees` / `LinkedWorktreePathForBranch` no longer error.
- `make lint` passes (0 issues).

Note: the user-facing remediation for an already-broken repo is still `git -C <repo> worktree prune`; this change makes yas tolerant so it doesn't break in the first place.

https://claude.ai/code/session_01VgKTFCZbzEXTvewRjXjMGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgKTFCZbzEXTvewRjXjMGQ)_